### PR TITLE
Create SNAT_range

### DIFF
--- a/SNAT_range
+++ b/SNAT_range
@@ -1,3 +1,13 @@
+#
+# Copyright 2016, Holger Kohn <holger(at)kohn-nf.de>, A10 Networks.
+# Version 1.2 - 20160424
+#
+# aFleX script to SNAT every single client IP to a single NAT IP
+#
+# ::DEBUG can be set to 1
+#
+# Scalability of this aFleX is unknown.
+#
 ## declaration:
 ## CIP -> Client-IP
 ## NIP -> NAT-IP

--- a/SNAT_range
+++ b/SNAT_range
@@ -1,0 +1,16 @@
+## declaration:
+## CIP -> Client-IP
+## NIP -> NAT-IP
+
+when RULE_INIT {
+  set DEBUG 0
+}
+when CLIENT_ACCEPTED {
+  if { [IP::addr [IP::client_addr] equals 128.178.199.0/24] } {
+    if { $::DEBUG > 1 } { log "aFlex has been fired" }
+    set CIP [IP::client_addr]
+    regsub "10.0.1." $CIP "10.0.2." NIP
+    snat $NIP
+    if { $::DEBUG > 1 } { log "SNAT from $CIP to $NIP" }  
+  } 
+}


### PR DESCRIPTION
This aFlex will SNAT a range of IP-addresses to another. This feature isn't implemented in ACOS until 4.1.0.